### PR TITLE
Use new singer-python metrics format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-zuora',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zuora'],
       install_requires=[
-          'singer-python==1.6.0a2',
+          'singer-python==1.6.0',
           'requests==2.12.4',
       ],
       entry_points='''


### PR DESCRIPTION
Use singer-python 1.6.0 and the new metrics format it brings. Example output:

```
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_create", "status": "succeeded"}, "value": 0.9041447639465332}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_poll", "status": "succeeded"}, "value": 0.33080124855041504}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export_attempt", "status": "succeeded"}, "value": 0.33103275299072266}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export", "status": "succeeded"}, "value": 1.4924097061157227}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_create", "status": "succeeded"}, "value": 0.30832386016845703}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_poll", "status": "succeeded"}, "value": 0.21793293952941895}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export_attempt", "status": "succeeded"}, "value": 0.21814322471618652}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export", "status": "succeeded"}, "value": 0.6784548759460449}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_create", "status": "succeeded"}, "value": 0.23065948486328125}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_poll", "status": "succeeded"}, "value": 0.18677282333374023}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export_attempt", "status": "succeeded"}, "value": 0.18697428703308105}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export", "status": "succeeded"}, "value": 0.5507082939147949}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_create", "status": "succeeded"}, "value": 0.19185709953308105}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_poll", "status": "succeeded"}, "value": 30.176257133483887}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_poll", "status": "succeeded"}, "value": 0.34927916526794434}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export_attempt", "status": "succeeded"}, "value": 30.52615475654602}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export", "status": "succeeded"}, "value": 31.06206512451172}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_create", "status": "succeeded"}, "value": 0.2926795482635498}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_poll", "status": "succeeded"}, "value": 1.1676890850067139}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export_attempt", "status": "succeeded"}, "value": 1.1678569316864014}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export", "status": "succeeded"}, "value": 1.5997121334075928}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_create", "status": "succeeded"}, "value": 0.18002915382385254}
INFO METRIC: {"metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "export_poll", "status": "succeeded"}, "value": 0.15338373184204102}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export_attempt", "status": "succeeded"}, "value": 0.15359807014465332}
INFO METRIC: {"metric": "job_duration", "type": "timer", "tags": {"job_type": "export", "status": "succeeded"}, "value": 0.46918463706970215}
INFO METRIC: {"metric": "record_count", "type": "counter", "tags": {"endpoint": "Subscription"}, "value": 1858}
```