### PR TITLE
Fix zuora deleted objects

### DIFF
--- a/tap_zuora/__init__.py
+++ b/tap_zuora/__init__.py
@@ -107,7 +107,7 @@ def do_sync(client, catalog, state, force_rest=False):
     singer.write_state(state)
     LOGGER.info("Finished sync")
 
-
+@singer.utils.handle_top_exception(LOGGER)
 def main():
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 

--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -32,8 +32,9 @@ class ExportFailed(Exception):
 class Aqua:
     ZOQL_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
-    # Zuora's documentation describes some objects which are not supported for deleted: https://knowledgecenter.zuora.com/DC_Developers/T_Aggregate_Query_API/B_Submit_Query/a_Export_Deleted_Data
-    # Note: After testing, the list above is not 100% accurate.
+    # Zuora's documentation describes some objects which are not supported for deleted
+    # See https://knowledgecenter.zuora.com/DC_Developers/T_Aggregate_Query_API/B_Submit_Query/a_Export_Deleted_Data
+    # and https://github.com/singer-io/tap-zuora/pull/8 for more info.
     DOES_NOT_SUPPORT_DELETED = ['AccountingPeriod', 'PaymentTransactionLog', 'RefundTransactionLog']
 
     @staticmethod


### PR DESCRIPTION
Zuora's documentation describes some objects not supporting deleted records:

https://knowledgecenter.zuora.com/DC_Developers/T_Aggregate_Query_API/B_Submit_Query/a_Export_Deleted_Data

After testing, we found the list to not be 100% accurate - AccountingCode works with deleted despite what the document shows.

When an object does not support them, the error will be:

> Objects included in the queries do not support the querying of deleted records. Remove Deleted section in the JSON request and retry the request