### PR TITLE
Feature/retry job timeout

### DIFF
--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -39,6 +39,9 @@ def format_datetime_zoql(datetime_str, date_format):
 class ExportFailed(Exception):
     pass
 
+class ExportTimedOut(ExportFailed):
+    def __init__(self):
+        super().__init__("TimedOut")
 
 class Aqua:
     ZOQL_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -110,6 +110,7 @@ def sync_rest_stream(client, state, stream, counter):
     if in_progress_job:
         file_ids = poll_job_until_done(in_progress_job, client, apis.Rest)
         counter = sync_file_ids(file_ids, client, state, stream, apis.Rest, counter)
+        state["bookmarks"][stream["tap_stream_id"]].pop("in_progress_job", None)
 
     if stream.get("replication_key"):
         sync_started = pendulum.utcnow()

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -133,8 +133,10 @@ def sync_rest_stream(client, state, stream, counter):
 def sync_stream(client, state, stream, force_rest=False):
     with singer.metrics.record_counter(stream["tap_stream_id"]) as counter:
         if force_rest:
+            counter = sync_rest_stream(client, state, stream, counter)
+        else:
             try:
-                counter = sync_rest_stream(client, state, stream, counter)
+                counter = sync_aqua_stream(client, state, stream, counter)
             except apis.ExportTimedOut as ex:
                 LOGGER.info("Export timed out, writing state before exiting...".format(ex))
                 singer.write_state(state)
@@ -144,7 +146,5 @@ def sync_stream(client, state, stream, force_rest=False):
                 state["bookmarks"][stream["tap_stream_id"]].pop("in_progress_job", None)
                 singer.write_state(state)
                 raise
-        else:
-            counter = sync_aqua_stream(client, state, stream, counter)
 
     return counter

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -142,7 +142,7 @@ def sync_stream(client, state, stream, force_rest=False):
                 singer.write_state(state)
                 raise
             except apis.ExportFailed as ex:
-                # Ensure that we don't cache a failing job
+                # Ensure that we don't retry a failing job
                 state["bookmarks"][stream["tap_stream_id"]].pop("in_progress_job", None)
                 singer.write_state(state)
                 raise


### PR DESCRIPTION
We have a time out set for exports, if there is too much data, this will trigger and fail the job. However, the way that the tap is querying Zuora's API is stateful, so this PR is to add functionality to store the in progress job in the state and request it on the next run.

**Requirements**
- Job ID should only be stored when it fails due to the taps' timeout
- Job ID should be cleared from state if the export is marked as "failed" by Zuora
- On successul export, job ID should be cleared from state