### PR TITLE
Fix/rest api describe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-zuora',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zuora'],
       install_requires=[
-          'singer-python==5.0.6',
+          'singer-python==5.1.0',
           'requests==2.12.4',
           'pendulum==1.2.0',
       ],

--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -195,7 +195,9 @@ class Rest:
 
     @staticmethod
     def get_query(stream, start_date, end_date):
-        fields = ", ".join(selected_fields(stream))
+        selected_field_names = selected_fields(stream)
+        dotted_field_names = joined_fields(selected_field_names, stream)
+        fields = ", ".join(dotted_field_names)
         query = "select {} from {}".format(fields, stream["tap_stream_id"])
 
         if stream.get("replication_key") and start_date and end_date:


### PR DESCRIPTION
- Fixes a bug where rest queries were not adding a '.' between the name of a joined object and the field.  
- Bumps the version of singer-python to 5.1.0 