### PR TITLE
Fix/long running export jobs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-zuora',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zuora'],
       install_requires=[
-          'singer-python==5.0.15',
+          'singer-python==5.1.1',
           'requests==2.12.4',
           'pendulum==1.2.0',
       ],

--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -105,10 +105,18 @@ class Aqua:
         fields = ", ".join(dotted_field_names)
         query = "select {} from {}".format(fields, stream["tap_stream_id"])
         if stream.get("replication_key"):
-            bookmark = state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]]
+            replication_key = stream["replication_key"]
+            bookmark = state["bookmarks"][stream["tap_stream_id"]][replication_key]
             start_date = format_datetime_zoql(bookmark, Aqua.ZOQL_DATE_FORMAT)
-            query += " where {} >= '{}'".format(stream["replication_key"], start_date)
-            query += " order by {} asc".format(stream["replication_key"])
+            window_end = state["bookmarks"][stream["tap_stream_id"]].get("current_window_end")
+            if bookmark == window_end:
+                query += " where {} = '{}'".format(replication_key, start_date)
+            else:
+                query += " where {} >= '{}'".format(replication_key, start_date)
+                if window_end:
+                    query += " and {} <= '{}'".format(replication_key,
+                                                      format_datetime_zoql(window_end, Aqua.ZOQL_DATE_FORMAT))
+            query += " order by {} asc".format(replication_key)
 
         LOGGER.info("Executing query: %s", query)
         return query

--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -40,8 +40,8 @@ class ExportFailed(Exception):
     pass
 
 class ExportTimedOut(ExportFailed):
-    def __init__(self):
-        super().__init__("TimedOut")
+    def __init__(self, timeout, unit):
+        super().__init__("Export failed (TimedOut): The job took longer than {} {}".format(timeout, unit))
 
 class Aqua:
     ZOQL_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -84,20 +84,16 @@ def sync_file_ids(file_ids, client, state, stream, api, counter):
 
 def sync_aqua_stream(client, state, stream, counter):
     file_ids = state["bookmarks"][stream["tap_stream_id"]].get("file_ids")
-    in_progress_job = state["bookmarks"][stream["tap_stream_id"]].get("in_progress_job")
-    if in_progress_job:
-        LOGGER.info("Found interrupted export job {}, resuming...".format(in_progress_job))
-        file_ids = poll_job_until_done(in_progress_job, client, apis.Aqua)
-        state["bookmarks"][stream["tap_stream_id"]]["file_ids"] = file_ids
-        singer.write_state(state)
-    elif not file_ids:
+    if not file_ids:
         job_id = apis.Aqua.create_job(client, state, stream)
-        state["bookmarks"][stream["tap_stream_id"]]["in_progress_job"] = job_id
         file_ids = poll_job_until_done(job_id, client, apis.Aqua)
         state["bookmarks"][stream["tap_stream_id"]]["file_ids"] = file_ids
         singer.write_state(state)
 
-    state["bookmarks"][stream["tap_stream_id"]].pop("in_progress_job", None)
+    window_end = state["bookmarks"][stream["tap_stream_id"]].pop("current_window_end", None)
+    if window_end:
+        # Save the window_end as the latest bookmark in case the window was empty
+        state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]] = window_end
     return sync_file_ids(file_ids, client, state, stream, apis.Aqua, counter)
 
 
@@ -128,6 +124,21 @@ def sync_rest_stream(client, state, stream, counter):
 
     return counter
 
+def handle_timeout(ex, stream, state):
+    if stream.get("replication_key"):
+        LOGGER.info("Export timed out, reducing query window and writing state before exiting...".format(ex))
+        window_bookmark = state["bookmarks"][stream["tap_stream_id"]].get("current_window_end")
+        previous_window_end = pendulum.parse(window_bookmark) if window_bookmark else pendulum.utcnow()
+        window_start = pendulum.parse(state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]])
+        if previous_window_end == window_start:
+            raise apis.ExportFailed("Export too large for smallest possible query window. " +
+                                    "Cannot subdivide any further. ({}: {})"
+                                    .format(stream["replication_key"], window_start)) from ex
+
+        half_day_range = (previous_window_end - window_start) // 2
+        current_window_end = previous_window_end - half_day_range
+        state["bookmarks"][stream["tap_stream_id"]]["current_window_end"] = current_window_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+        singer.write_state(state)
 
 def sync_stream(client, state, stream, force_rest=False):
     with singer.metrics.record_counter(stream["tap_stream_id"]) as counter:
@@ -137,13 +148,7 @@ def sync_stream(client, state, stream, force_rest=False):
             try:
                 counter = sync_aqua_stream(client, state, stream, counter)
             except apis.ExportTimedOut as ex:
-                LOGGER.info("Export timed out, writing state before exiting...".format(ex))
-                singer.write_state(state)
-                raise
-            except apis.ExportFailed as ex:
-                # Ensure that we don't retry a failing job
-                state["bookmarks"][stream["tap_stream_id"]].pop("in_progress_job", None)
-                singer.write_state(state)
+                handle_timeout(ex, stream, state)
                 raise
 
     return counter

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -8,7 +8,6 @@ import singer
 from singer import transform
 from tap_zuora import apis
 
-
 PARTNER_ID = "salesforce"
 DEFAULT_POLL_INTERVAL = 60
 DEFAULT_JOB_TIMEOUT = 5400
@@ -42,7 +41,7 @@ def poll_job_until_done(job_id, client, api):
 
         time.sleep(DEFAULT_POLL_INTERVAL)
 
-    raise apis.ExportTimedOut()
+    raise apis.ExportTimedOut(DEFAULT_JOB_TIMEOUT // 60, "minutes")
 
 
 def sync_file_ids(file_ids, client, state, stream, api, counter):


### PR DESCRIPTION
In 0.3.0, we gave the tap the ability to resume an AQuA export job if it timed out on the first run. This proved to not be doable since the Zuora API will silently abort and retry a job if it takes over 8 hours, resulting in the tap just constantly trying to request a job that would never succeed.

This pull request replaces that functionality with a window reduction method that will cut the query window in half as it times out until the window reaches a single second range, in which case it will fail with a message stating this fact.

Hopefully there isn't a second of data that doesn't fit in a single export job, but it is possible (in the case of a bulk migration of some sort). If that's the case, adjusting the syncing range past the data causing the blockage would be the accepted workaround.