### PR TITLE
Refactor and add a retry loop for timed out aqua streams.

### DIFF
--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -81,20 +81,44 @@ def sync_file_ids(file_ids, client, state, stream, api, counter):
     singer.write_state(state)
     return counter
 
+def handle_timeout(ex, stream, state):
+    if stream.get("replication_key"):
+        LOGGER.info("Export timed out, reducing query window and writing state.".format(ex))
+        window_bookmark = state["bookmarks"][stream["tap_stream_id"]].get("current_window_end")
+        previous_window_end = pendulum.parse(window_bookmark) if window_bookmark else pendulum.utcnow()
+        window_start = pendulum.parse(state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]])
+        if previous_window_end == window_start:
+            raise apis.ExportFailed("Export too large for smallest possible query window. " +
+                                    "Cannot subdivide any further. ({}: {})"
+                                    .format(stream["replication_key"], window_start)) from ex
 
-def sync_aqua_stream(client, state, stream, counter):
-    file_ids = state["bookmarks"][stream["tap_stream_id"]].get("file_ids")
-    if not file_ids:
-        job_id = apis.Aqua.create_job(client, state, stream)
-        file_ids = poll_job_until_done(job_id, client, apis.Aqua)
-        state["bookmarks"][stream["tap_stream_id"]]["file_ids"] = file_ids
+        half_day_range = (previous_window_end - window_start) // 2
+        current_window_end = previous_window_end - half_day_range
+        state["bookmarks"][stream["tap_stream_id"]]["current_window_end"] = current_window_end.strftime("%Y-%m-%dT%H:%M:%SZ")
         singer.write_state(state)
 
-    window_end = state["bookmarks"][stream["tap_stream_id"]].pop("current_window_end", None)
-    if window_end:
-        # Save the window_end as the latest bookmark in case the window was empty
-        state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]] = window_end
-    return sync_file_ids(file_ids, client, state, stream, apis.Aqua, counter)
+def sync_aqua_stream(client, state, stream, counter):
+    timed_out = False
+    try:
+        file_ids = state["bookmarks"][stream["tap_stream_id"]].get("file_ids")
+        if not file_ids:
+            job_id = apis.Aqua.create_job(client, state, stream)
+            file_ids = poll_job_until_done(job_id, client, apis.Aqua)
+            state["bookmarks"][stream["tap_stream_id"]]["file_ids"] = file_ids
+            singer.write_state(state)
+
+        window_end = state["bookmarks"][stream["tap_stream_id"]].pop("current_window_end", None)
+        if window_end:
+            # Save the window_end as the latest bookmark in case the window was empty
+            state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]] = window_end
+        return sync_file_ids(file_ids, client, state, stream, apis.Aqua, counter)
+    except apis.ExportTimedOut as ex:
+        handle_timeout(ex, stream, state)
+        timed_out = True
+
+    if timed_out:
+        LOGGER.info("Retrying timed out sync job...")
+        return sync_aqua_stream(client, state, stream, counter)
 
 
 def sync_rest_stream(client, state, stream, counter):
@@ -124,31 +148,11 @@ def sync_rest_stream(client, state, stream, counter):
 
     return counter
 
-def handle_timeout(ex, stream, state):
-    if stream.get("replication_key"):
-        LOGGER.info("Export timed out, reducing query window and writing state before exiting...".format(ex))
-        window_bookmark = state["bookmarks"][stream["tap_stream_id"]].get("current_window_end")
-        previous_window_end = pendulum.parse(window_bookmark) if window_bookmark else pendulum.utcnow()
-        window_start = pendulum.parse(state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]])
-        if previous_window_end == window_start:
-            raise apis.ExportFailed("Export too large for smallest possible query window. " +
-                                    "Cannot subdivide any further. ({}: {})"
-                                    .format(stream["replication_key"], window_start)) from ex
-
-        half_day_range = (previous_window_end - window_start) // 2
-        current_window_end = previous_window_end - half_day_range
-        state["bookmarks"][stream["tap_stream_id"]]["current_window_end"] = current_window_end.strftime("%Y-%m-%dT%H:%M:%SZ")
-        singer.write_state(state)
-
 def sync_stream(client, state, stream, force_rest=False):
     with singer.metrics.record_counter(stream["tap_stream_id"]) as counter:
         if force_rest:
             counter = sync_rest_stream(client, state, stream, counter)
         else:
-            try:
-                counter = sync_aqua_stream(client, state, stream, counter)
-            except apis.ExportTimedOut as ex:
-                handle_timeout(ex, stream, state)
-                raise
+            counter = sync_aqua_stream(client, state, stream, counter)
 
     return counter


### PR DESCRIPTION
This makes it so that the retry logic for AQuA streams that time out is repeated in the same tap run, allowing it to complete successfully much quicker than otherwise.