### PR TITLE
Fix/state should tolerate nulls

### DIFF
--- a/tap_zuora/__init__.py
+++ b/tap_zuora/__init__.py
@@ -58,7 +58,8 @@ def validate_state(config, catalog, state):
         if not stream.replication_key:
             continue
 
-        if stream.replication_key not in state["bookmarks"][stream.tap_stream_id]:
+        if stream.replication_key not in state["bookmarks"][stream.tap_stream_id] or \
+           state["bookmarks"][stream.tap_stream_id][stream.replication_key] is None:
             LOGGER.info("Setting start date for %s to %s", stream.tap_stream_id, config["start_date"])
             state["bookmarks"][stream.tap_stream_id][stream.replication_key] = config["start_date"]
 

--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -23,14 +23,14 @@ def selected_fields(stream):
 
 def joined_fields(fields, stream):
     mdata = metadata.to_map(stream['metadata'])
-    joined_fields = []
+    joined_fields_list = []
     for field_name in fields:
         joined_obj = metadata.get(mdata, ('properties', field_name), 'tap-zuora.joined_object')
         if joined_obj:
-            joined_fields.append(joined_obj + '.' + field_name.replace(joined_obj, ""))
+            joined_fields_list.append(joined_obj + '.' + field_name.replace(joined_obj, ""))
         else:
-            joined_fields.append(field_name)
-    return joined_fields
+            joined_fields_list.append(field_name)
+    return joined_fields_list
 
 def format_datetime_zoql(datetime_str, date_format):
     return pendulum.parse(datetime_str, tz=pendulum.timezone("UTC")).strftime(date_format)

--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -56,8 +56,8 @@ def get_field_dict(client, stream_name):
             LOGGER.info("%s.%s has an unsupported data type", stream_name, field_info["name"])
             supported = False
         elif "export" not in field_info["contexts"]:
-           LOGGER.info("%s.%s not available for export", stream_name, field_info["name"])
-           continue
+            LOGGER.info("%s.%s not available for export", stream_name, field_info["name"])
+            continue
 
         field_dict[field_info["name"]] = {
             "type": field_info["type"],
@@ -89,10 +89,10 @@ def discover_stream_names(client):
     return [t.text for t in etree.findall("./object/name")]
 
 
-def discover_stream(client, stream_name, force_rest):
+def discover_stream(client, stream_name, force_rest): # pylint: disable=too-many-branches
     try:
         field_dict = get_field_dict(client, stream_name)
-    except ApiException as e:
+    except ApiException:
         return None
 
     properties = {}
@@ -111,8 +111,6 @@ def discover_stream(client, stream_name, force_rest):
             field_properties["format"] = "date-time"
         else:
             field_properties["type"] = props["type"]
-
-        path = "{}.{}".format(stream_name, field_name)
 
         if props["supported"]:
             field_properties["type"] = [field_properties["type"], "null"]
@@ -175,5 +173,5 @@ def discover_streams(client, force_rest):
             failed_stream_names.append(stream_name)
 
     if failed_stream_names:
-        LOGGER.info('Failed to discover following streams: {}'.format(failed_stream_names))
+        LOGGER.info('Failed to discover following streams: %s', failed_stream_names)
     return streams

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -126,7 +126,7 @@ def sync_rest_stream(client, state, stream, counter):
 
 def handle_timeout(ex, stream, state):
     if stream.get("replication_key"):
-        LOGGER.info("Export timed out, reducing query window and writing state before exiting...".format(ex))
+        LOGGER.info("Export timed out, reducing query window and writing state before exiting...")
         window_bookmark = state["bookmarks"][stream["tap_stream_id"]].get("current_window_end")
         previous_window_end = pendulum.parse(window_bookmark) if window_bookmark else pendulum.utcnow()
         window_start = pendulum.parse(state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]])

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -83,7 +83,7 @@ def sync_file_ids(file_ids, client, state, stream, api, counter):
 
 def handle_timeout(ex, stream, state):
     if stream.get("replication_key"):
-        LOGGER.info("Export timed out, reducing query window and writing state.".format(ex))
+        LOGGER.info("Export timed out, reducing query window and writing state.")
         window_bookmark = state["bookmarks"][stream["tap_stream_id"]].get("current_window_end")
         previous_window_end = pendulum.parse(window_bookmark) if window_bookmark else pendulum.utcnow()
         window_start = pendulum.parse(state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]])


### PR DESCRIPTION
There is a case where the state value can be saved as null due to exceptional circumstances. This change makes it so that the state populating logic will interpret null the same way it would for a missing bookmark, and fall back to `start_date`.

Also fixed pylint issues that have been hanging around.