### PR TITLE
Skip writing a bookmark if the record has none

### DIFF
--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -63,6 +63,10 @@ def sync_file_ids(file_ids, client, state, stream, api, counter):
             record = transform(row, stream['schema'])
             if stream.get("replication_key"):
                 bookmark = record.get(stream["replication_key"])
+                if not bookmark:
+                    # There's a chance we get back a bad record here, and we don't want to null the bookmark
+                    continue
+
                 if bookmark and bookmark < start_date:
                     continue
 


### PR DESCRIPTION
Found out that if a weird record comes back from Zuora and its missing a bookmark, we'll end up writing a null bookmark to our state which wipes out how far we've gone.