### PR TITLE
Attempt to retry once if TCP socket closes due to session timeout

### DIFF
--- a/tap_zuora/client.py
+++ b/tap_zuora/client.py
@@ -41,6 +41,9 @@ class Client:
         self.partner_id = partner_id
         self._session = requests.Session()
 
+        adapter = requests.adapters.HTTPAdapter(max_retries=1) # Try again in the case the TCP socket closes
+        self._session.mount('https://', adapter)
+
     @staticmethod
     def from_config(config):
         sandbox = config.get('sandbox', False) == 'true'


### PR DESCRIPTION
If a TCP socket is left open for too long (~2 hours), Zuora will snap the connection. This adds a retry to the Session object's HTTPHandler in order to re-open the socket with a single retry in the event of a snapped connection.