### PR TITLE
Remove file id from state and exit in the event of a 404

### DIFF
--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -61,7 +61,7 @@ def sync_file_ids(file_ids, client, state, stream, api, counter):
             if ex.resp.status_code == 404:
                 state["bookmarks"][stream["tap_stream_id"]].pop("file_ids", None)
                 singer.write_state(state)
-                raise
+            raise
         header = parse_header_line(next(lines), stream["tap_stream_id"])
         for line in lines:
             if not line:

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -56,9 +56,10 @@ def sync_file_ids(file_ids, client, state, stream, api, counter):
         try:
             lines = api.stream_file(client, file_id)
         except ApiException as ex:
-            # If the file has been deleted, write state with popped file_id removed and re-raise.
-            # Don't advance the bookmark until the sync window can be completed fully.
+            # If the file has been deleted, write state with "file_ids" removed and re-raise.
+            # Don't advance the bookmark until all files in the window have been synced.
             if ex.resp.status_code == 404:
+                state["bookmarks"][stream["tap_stream_id"]].pop("file_ids", None)
                 singer.write_state(state)
                 raise
         header = parse_header_line(next(lines), stream["tap_stream_id"])

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -61,6 +61,9 @@ def sync_file_ids(file_ids, client, state, stream, api, counter):
             if ex.resp.status_code == 404:
                 state["bookmarks"][stream["tap_stream_id"]].pop("file_ids", None)
                 singer.write_state(state)
+                raise Exception(("File ID {} has been deleted, making the sync window invalid. "
+                                "Removing partially exported files from state and will resume from bookmark on the next extraction.")
+                                .format(file_id)) from ex
             raise
         header = parse_header_line(next(lines), stream["tap_stream_id"])
         for line in lines:


### PR DESCRIPTION
Zuora clears out exported files every 72 hours. If for some reason, we have a state value that contains one of these, and it ages out. It will never be replicated.

In the event that Zuora returns a 404 for a file, this PR will make the tap save state with the ID removed, and fail out, to be retried the next time around.

An important note is that the tap will not continue, since it wasn't able to retrieve the data for that file, so on the next run it will retry the range from the bookmark value present.