### PR TITLE
Use T delimited format for ZOQL AQuA export queries

### DIFF
--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -56,7 +56,9 @@ class ExportTimedOut(ExportFailed):
         super().__init__("Export failed (TimedOut): The job took longer than {} {}".format(timeout, unit))
 
 class Aqua:
-    ZOQL_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+    ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+    # Specifying incrementalTime requires this format, but ZOQL requires the 'T'
+    PARAMETER_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
     # Zuora's documentation describes some objects which are not supported for deleted
     # See https://knowledgecenter.zuora.com/DC_Developers/T_Aggregate_Query_API/B_Submit_Query/a_Export_Deleted_Data
@@ -148,7 +150,7 @@ class Aqua:
             start_date = state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]]
             inc_pen = pendulum.parse(start_date)
             inc_pen = inc_pen.astimezone(pendulum.timezone("America/Los_Angeles"))
-            payload["incrementalTime"] = inc_pen.strftime(Aqua.ZOQL_DATE_FORMAT)
+            payload["incrementalTime"] = inc_pen.strftime(Aqua.PARAMETER_DATE_FORMAT)
 
         return payload
 


### PR DESCRIPTION
It appears that in some cases, the Zuora API will silently return 0 records in the case where the ZOQL date format is not `YYYY-mm-ddTHH:MM:ss` with the "T" delimiter. This has been confirmed by Zuora support themselves as the cause of this issue, and is indicated in [this piece of documentation](https://knowledgecenter.zuora.com/DC_Developers/BB_Export_ZOQL/G_Dates_and_Datetimes).

It's unclear why this works sometimes, but in testing, it appears to work the same given the other, so my expectation is that there is an edge case in the Zuora backend.

This PR changes the date format for ZOQL exports from the AQuA API to match this style.