### PR TITLE
Enable OAuth2 authentication

### DIFF
--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -1,6 +1,7 @@
 import pendulum
 import singer
 from singer import metadata
+from client import ApiException
 
 
 MAX_EXPORT_DAYS = 30
@@ -59,7 +60,7 @@ class Aqua:
     ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
     # Specifying incrementalTime requires this format, but ZOQL requires the 'T'
     PARAMETER_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-
+    
     # Zuora's documentation describes some objects which are not supported for deleted
     # See https://knowledgecenter.zuora.com/DC_Developers/T_Aggregate_Query_API/B_Submit_Query/a_Export_Deleted_Data
     # and https://github.com/singer-io/tap-zuora/pull/8 for more info.
@@ -301,7 +302,12 @@ class Rest:
             "Query": query,
             "Format": "csv"
         }
-        resp = client.rest_request("POST", endpoint, json=payload).json()
+
+        # With OAuth2, some entities that exist in Describe might not be available in the export
+        try:
+            resp = client.rest_request("POST", endpoint, json=payload).json()
+        except ApiException:
+            return "unavailable"
 
         if resp["Success"]:
             return "available"

--- a/tap_zuora/client.py
+++ b/tap_zuora/client.py
@@ -87,7 +87,7 @@ class Client:
         return resp
 
     def is_auth_token_valid(self):
-        if self.oauth2_token and self.token_expiration_date and pendulum.now().utcnow().diff(self.token_expiration_date).in_seconds() > 60: # Allows at least one minute of breathing room
+        if self.oauth2_token and self.token_expiration_date and pendulum.utcnow().diff(self.token_expiration_date).in_seconds() > 60: # Allows at least one minute of breathing room
             return True
         
         return False
@@ -105,7 +105,7 @@ class Client:
         }
 
         token = self._request('POST', url, data=payload).json()
-        self.token_expiration_date = pendulum.now().utcnow().add(seconds=token['expires_in'])
+        self.token_expiration_date = pendulum.utcnow().add(seconds=token['expires_in'])
 
         return token
 


### PR DESCRIPTION
Hello!

I work for Stack Overflow, and we've been requiring the usage of OAuth2 as an authentication method for this tap. So here is a PR with a simple, but effective, Bearer token manager implemented.
Tested locally with REST and AQUA calls and it's backwards compatible.

Please do reach out with any changes I might need to make and I do apologize in advance for any inconveniences.

Here are the changes I made:
- Added logic to retrieve a Bearer token using the Username and Password fields as cliend_id and client_secret
- Added logic to manage the existance of a Bearer token
- Added checks to see which authorization method to use if OAuth2 is enabled
- Added new error check while checking for existing exports that is required while using OAuth2