### PR TITLE
Add timezone to AQuA queries

### DIFF
--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -56,6 +56,7 @@ class ExportTimedOut(ExportFailed):
         super().__init__("Export failed (TimedOut): The job took longer than {} {}".format(timeout, unit))
 
 class Aqua:
+    api_type = "AQUA"
     ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
     # Specifying incrementalTime requires this format, but ZOQL requires the 'T'
     PARAMETER_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -231,6 +232,7 @@ class Aqua:
 
 
 class Rest:
+    api_type = "REST"
     ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
     @staticmethod

--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -56,7 +56,6 @@ class ExportTimedOut(ExportFailed):
         super().__init__("Export failed (TimedOut): The job took longer than {} {}".format(timeout, unit))
 
 class Aqua:
-    api_type = "AQUA"
     ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
     # Specifying incrementalTime requires this format, but ZOQL requires the 'T'
     PARAMETER_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -127,7 +126,7 @@ class Aqua:
             if bookmark == window_end:
                 query += " where {} = '{}'".format(replication_key, start_date)
             else:
-                query += " where {} >= '{}'".format(replication_key, start_date)
+                query += " where {} >= '{} (+00:00)'".format(replication_key, start_date)
                 if window_end:
                     query += " and {} <= '{}'".format(replication_key,
                                                       format_datetime_zoql(window_end, Aqua.ZOQL_DATE_FORMAT))
@@ -232,7 +231,6 @@ class Aqua:
 
 
 class Rest:
-    api_type = "REST"
     ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
     @staticmethod

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -101,9 +101,8 @@ def sync_file_ids(file_ids, client, state, stream, api, counter): # pylint: disa
                     continue
 
                 singer.write_record(stream["tap_stream_id"], record)
-                if api.api_type == 'REST':
-                    state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]] = bookmark
-                    singer.write_state(state)
+                state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]] = bookmark
+                singer.write_state(state)
             else:
                 singer.write_record(stream["tap_stream_id"], record)
 
@@ -117,11 +116,6 @@ def sync_file_ids(file_ids, client, state, stream, api, counter): # pylint: disa
         singer.write_state(state)
 
     state["bookmarks"][stream["tap_stream_id"]]["file_ids"] = None
-
-    # the new bookmark is the end of the window
-    window_end = state["bookmarks"][stream["tap_stream_id"]].pop("current_window_end", None)
-    if api.api_type == 'AQUA' and window_end:
-        state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]] = window_end
     singer.write_state(state)
     return counter
 
@@ -146,15 +140,15 @@ def sync_aqua_stream(client, state, stream, counter):
     try:
         file_ids = state["bookmarks"][stream["tap_stream_id"]].get("file_ids")
         if not file_ids:
-            # set window stop time to now
-            if not state["bookmarks"][stream["tap_stream_id"]].get("current_window_end"):
-                window_end = singer.utils.strftime(singer.utils.now())
-                state["bookmarks"][stream["tap_stream_id"]]["current_window_end"] = window_end
             job_id = apis.Aqua.create_job(client, state, stream)
             file_ids = poll_job_until_done(job_id, client, apis.Aqua)
             state["bookmarks"][stream["tap_stream_id"]]["file_ids"] = file_ids
             singer.write_state(state)
 
+        window_end = state["bookmarks"][stream["tap_stream_id"]].pop("current_window_end", None)
+        if window_end:
+            # Save the window_end as the latest bookmark in case the window was empty
+            state["bookmarks"][stream["tap_stream_id"]][stream["replication_key"]] = window_end
         return sync_file_ids(file_ids, client, state, stream, apis.Aqua, counter)
     except apis.ExportTimedOut as ex:
         handle_aqua_timeout(ex, stream, state)


### PR DESCRIPTION
We were seeing an issue where our query was being interpreted as the timezone of the account holder,  and we were bookmarking based off of the returned data (in UTC), which led to data discrepancies.  

This PR adds the timezone to the query to ensure its interpreted as UTC.