### PR TITLE
Add timezone info to REST queries

### DIFF
--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -250,7 +250,7 @@ class Rest:
         if stream.get("replication_key") and start_date and end_date:
             start_date = format_datetime_zoql(start_date, Rest.ZOQL_DATE_FORMAT)
             end_date = format_datetime_zoql(end_date, Rest.ZOQL_DATE_FORMAT)
-            query += " where {} >= '{}'".format(stream["replication_key"], start_date)
+            query += " where {} >= '{} (+00:00)'".format(stream["replication_key"], start_date)
             query += " and {} < '{}'".format(stream["replication_key"], end_date)
 
         LOGGER.info("Executing query: %s", query)


### PR DESCRIPTION
This change is very much like #37.

All configurations of the timezone change were tested and the one in this PR returned the most data.
And by all configurations, I mean:
- Given that the query looks like `a <= b < c`, I used the same bookmark to make the following queries:
  - `a <= b < c`
  - `a (+00:00) <= b < c`
  - `a <= b < c (+00:00)`
  - `a (+00:00) <= b < c (+00:00)`