### PR TITLE
Add http_request_timer to API calls

### DIFF
--- a/tap_zuora/client.py
+++ b/tap_zuora/client.py
@@ -1,7 +1,6 @@
 import requests
-
 import singer
-
+from singer import metrics
 
 IS_AQUA = False
 IS_REST = True
@@ -77,9 +76,11 @@ class Client:
         return resp
 
     def aqua_request(self, method, url, **kwargs):
-        url = self.get_url(url, rest=False)
-        return self._request(method, url, auth=self.aqua_auth, **kwargs)
+        with metrics.http_request_timer(url):
+            url = self.get_url(url, rest=False)
+            return self._request(method, url, auth=self.aqua_auth, **kwargs)
 
     def rest_request(self, method, url, **kwargs):
-        url = self.get_url(url, rest=True)
-        return self._request(method, url, headers=self.rest_headers, **kwargs)
+        with metrics.http_request_timer(url):
+            url = self.get_url(url, rest=True)
+            return self._request(method, url, headers=self.rest_headers, **kwargs)


### PR DESCRIPTION
Fixes #40

Tests passing and metrics captured:

```
        2019-06-22 23:27:11,694Z    tap - INFO POST: https://apisandbox.zuora.com/apps/api/batch-query/
        2019-06-22 23:27:13,867Z    tap - INFO METRIC Point(metric_type='timer', metric='http_request_duration', value=2.1726622581481934, tags={'endpoint': 'apps/api/batch-query/', 'status': 'succeeded'})
        2019-06-22 23:27:13,871Z    tap - INFO GET: https://rest.apisandbox.zuora.com/v1/describe/TaxationItem
        2019-06-22 23:27:14,061Z    tap - INFO METRIC Point(metric_type='timer', metric='http_request_duration', value=0.19077849388122559, tags={'endpoint': 'v1/describe/TaxationItem', 'status': 'succeeded'})
```