### PR TITLE
Remove timezone from query

### DIFF
--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -242,7 +242,7 @@ class Rest:
         if stream.get("replication_key") and start_date and end_date:
             start_date = format_datetime_zoql(start_date, Rest.ZOQL_DATE_FORMAT)
             end_date = format_datetime_zoql(end_date, Rest.ZOQL_DATE_FORMAT)
-            query += " where {} >= '{} (+00:00)'".format(stream["replication_key"], start_date)
+            query += " where {} >= '{}'".format(stream["replication_key"], start_date)
             query += " and {} < '{}'".format(stream["replication_key"], end_date)
 
         LOGGER.info("Executing query: %s", query)


### PR DESCRIPTION
# Description of change
This PR follows Zuora's recommendation to make the timestamps in the tap queries ISO 8601 timestamps.

# Manual QA steps
 - 
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
