### PR TITLE
Fix/concurrent aqua jobs rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.2
+  * Delete AQuA API discovery exports when they are no longer needed, to reduce concurrency of jobs. [#53](https://github.com/singer-io/tap-zuora/pull/53)
+  * Add exponential backoff to AQuA requests for 429 errors [#53](https://github.com/singer-io/tap-zuora/pull/53)
+
 ## 1.2.1
   * Fixed REST queries to use iso-8601 timestamp [#50](https://github.com/singer-io/tap-zuora/pull/50)
 

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,10 @@ setup(name='tap-zuora',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zuora'],
       install_requires=[
-          'singer-python==5.1.1',
+          'singer-python==5.7.0',
           'requests==2.20.0',
           'pendulum==1.2.0',
+          'backoff==1.8.0',
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zuora',
-      version='1.2.1',
+      version='1.2.2',
       description='Singer.io tap for extracting data from the Zuora API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Zuora is now enforcing a limit on concurrent AQuA jobs, which revealed a shortcoming in how this tap discovers available objects for AQuA export.

In short, the tap will make a small export of 1 row per-object discovered to check two things:
1. Whether the object is able to be exported by the config provided
2. Whether it is available with Deleted data for the config provided

If too many concurrent jobs are running, Zuora will return a 429, so this PR adds a retry on AQuA requests that get a 429, and also adds a call to [cancel the newly created export job](https://knowledgecenter.zuora.com/Central_Platform/API/AB_Aggregate_Query_API/F_Delete_Executing_Job) once the information that is needed is retrieved into memory. This should avoid the tap failing due to this new scenario.

# Manual QA steps
 - Ran through this with credentials that were running into the export limit and confirmed that both changes mentioned above function as expected.
 
# Risks
 - Low, bumped singer-python version to get a more up to date version of backoff
 - If a set of credentials is restricted in a way that returns a non-200, nor 429 response, the `DELETE` call could cause a failure.
     - This is only speculation because I have only seen 200 responses with error messages returned from Zuora. I do not have a concrete case of this.
 
# Rollback steps
 - revert this branch, bump patch version, re-release
