### PR TITLE
Enforce utc in queries in REST api

### DIFF
--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -236,7 +236,7 @@ class Aqua:
 
 
 class Rest:
-    ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+    ZOQL_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
     @staticmethod
     def make_payload(query):
@@ -255,8 +255,8 @@ class Rest:
         if stream.get("replication_key") and start_date and end_date:
             start_date = format_datetime_zoql(start_date, Rest.ZOQL_DATE_FORMAT)
             end_date = format_datetime_zoql(end_date, Rest.ZOQL_DATE_FORMAT)
-            query += " where {} >= '{}Z'".format(stream["replication_key"], start_date)
-            query += " and {} < '{}Z'".format(stream["replication_key"], end_date)
+            query += " where {} >= '{}'".format(stream["replication_key"], start_date)
+            query += " and {} < '{}'".format(stream["replication_key"], end_date)
 
         LOGGER.info("Executing query: %s", query)
         return query

--- a/tap_zuora/apis.py
+++ b/tap_zuora/apis.py
@@ -255,8 +255,8 @@ class Rest:
         if stream.get("replication_key") and start_date and end_date:
             start_date = format_datetime_zoql(start_date, Rest.ZOQL_DATE_FORMAT)
             end_date = format_datetime_zoql(end_date, Rest.ZOQL_DATE_FORMAT)
-            query += " where {} >= '{}'".format(stream["replication_key"], start_date)
-            query += " and {} < '{}'".format(stream["replication_key"], end_date)
+            query += " where {} >= '{}Z'".format(stream["replication_key"], start_date)
+            query += " and {} < '{}Z'".format(stream["replication_key"], end_date)
 
         LOGGER.info("Executing query: %s", query)
         return query


### PR DESCRIPTION
# Description of change
Currently, our REST api queries are not specifying a timezone. Based on code elsewhere in the tap, it looks like we assume no timezone specified means UTC, but we were seeing behavior where that wasn't the case. This change explicitly forces UTC.
See https://knowledgecenter.zuora.com/Central_Platform/Query/Export_ZOQL/G_Dates_and_Datetimes#Specify_time_zones for more info 

# Manual QA steps
 - I ran a sync that queried the span of an hour and didn't get a known existing record with an updated at within that hour. I then ran a sync that queried the span of that hour, plus three hours before that hour. This sync did get the missing record.
 - I ran the same initial sync that spanned one hour with this change, and the record showed up properly.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
