### PR TITLE
Increase aqua job timeout to 12 hrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.3
+  * Increase artifical timeout to 12 hrs to accomodate larger AQuA full table requests. [#62](https://github.com/singer-io/tap-zuora/pull/62)
+
 ## 1.3.2
   * Catch ApiExceptions for unavailable streams. [#60](https://github.com/singer-io/tap-zuora/pull/60)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zuora',
-      version='1.3.2',
+      version='1.3.3',
       description='Singer.io tap for extracting data from the Zuora API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zuora/sync.py
+++ b/tap_zuora/sync.py
@@ -11,7 +11,7 @@ from tap_zuora.exceptions import ApiException
 
 PARTNER_ID = "salesforce"
 DEFAULT_POLL_INTERVAL = 60
-DEFAULT_JOB_TIMEOUT = 5400
+DEFAULT_JOB_TIMEOUT = 12 * 60 * 60 # 12 hrs in seconds
 MAX_EXPORT_DAYS = 30
 
 LOGGER = singer.get_logger()


### PR DESCRIPTION
# Description of change
This timeout appears arbitrary, and isn't based on any inability of Zuora to fulfill this request. In the event that a stream just has a ton of data in it, the timeout can keep recurring and look like the tap is dead in the water.

This PR attempts to avoid this scenario by simply increasing the timeout by a lot, rather than introducing any complicated retry counting logic, bailout logic, or some kind of expo backoff.

# Manual QA steps
 - None relying on automation coverage for a smoke test
 
# Risks
 - Low, this is just the increase of an existing value. Impact is scoped to the sync file.
 
# Rollback steps
 - revert this branch, release new patch version
