### PR TITLE
skip BillingPreviewRun stream during discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.4
+  * Skip 'BillingPreviewRun' stream since 'Id' field is not available for export [#64](https://github.com/singer-io/tap-zuora/pull/64)
+  
 ## 1.3.3
   * Increase artifical timeout to 12 hrs to accomodate larger AQuA full table requests. [#62](https://github.com/singer-io/tap-zuora/pull/62)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zuora',
-      version='1.3.3',
+      version='1.3.4',
       description='Singer.io tap for extracting data from the Zuora API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Adds `UNAVAILABLE_STREAMS` to skip during discovery. In Support tickets, BillingPreviewRun during discovery `key_property: Id` was not in discovered fields. 
From the logs we see that  BillingPreviewRun.Id is not available for export, along with most of the fields of any value. 

> tap - INFO BillingPreviewRun.AssumeRenewal not available for export
> tap - INFO BillingPreviewRun.Batches not available for export
> tap - INFO BillingPreviewRun.ChargeTypeToExclude not available for export
> tap - INFO BillingPreviewRun.CreatedById not available for export
> tap - INFO BillingPreviewRun.CreatedDate not available for export
> tap - INFO BillingPreviewRun.EndDate has an unsupported data type
> tap - INFO BillingPreviewRun.ErrorMessage not available for export
> tap - INFO BillingPreviewRun.Id not available for export
> tap - INFO BillingPreviewRun.IncludingDraftItems not available for export
> tap - INFO BillingPreviewRun.IncludingEvergreenSubscription not available for export
> tap - INFO BillingPreviewRun.ResultFileUrl not available for export
> tap - INFO BillingPreviewRun.RunNumber not available for export
> tap - INFO BillingPreviewRun.StartDate has an unsupported data type
> tap - INFO BillingPreviewRun.Status not available for export
> tap - INFO BillingPreviewRun.SucceededAccounts not available for export
> tap - INFO BillingPreviewRun.TargetDate not available for export
> tap - INFO BillingPreviewRun.TotalAccounts not available for export
> tap - INFO BillingPreviewRun.UpdatedById not available for export
> tap - INFO BillingPreviewRun.UpdatedDate not available for export

# Manual QA steps
 - Tested locally. Error occurs without the code change on both Aqua and Rest APIs, and is fixed with the stream skipped. 
 
# Risks
 - 

# Rollback steps
 - revert this branch
