### PR TITLE
Return empty dict for non-discoverable stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.1
+  * Skip saving schema for non-discoverable streams since replication key field is not available for export [#72](https://github.com/singer-io/tap-zuora/pull/72)
+
 ## 1.4.0
   * Code Refactoring [#68](https://github.com/singer-io/tap-zuora/pull/68)
     - Makes a non-exportable field as unsupported in catalog file during discovery phase

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-zuora",
-    version="1.4.0",
+    version="1.4.1",
     description="Singer.io tap for extracting data from the Zuora API",
     author="Stitch",
     url="https://singer.io",

--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -103,7 +103,7 @@ def get_field_dict(client: Client, stream_name: str) -> Dict:
                 f"Skipping stream {stream_name} since required field {field_info['name']}" f" not available for export"
             )
             field_dict = {}
-            break
+            return field_dict
 
         # Skip the non-required field if is not exportable
         if "export" not in field_info["contexts"]:


### PR DESCRIPTION
# Description of change
Latest release of 1.4.0 is breaking for certain client while discovering BillingPreviewRun
Instead of breaking loop, we should return empty dict

# Manual QA steps
 -

# Risks
 Low, this is client specific.

# Rollback steps
 - revert this branch
