### PR TITLE
TDL-21785 Don't add related object to field_dict if unqueryable

### DIFF
--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -64,6 +64,10 @@ UNSUPPORTED_FIELDS_FOR_REST = {
     "Usage": ["ImportId"],
 }
 
+UNSUPPORTED_RELATED_OBJECTS = {
+    "SubscriptionStatusHistory",
+    }
+
 REQUIRED_KEYS = ["Id"] + REPLICATION_KEYS
 
 LOGGER = singer.get_logger()
@@ -117,7 +121,14 @@ def get_field_dict(client: Client, stream_name: str) -> Dict:
         }
 
     for related_object in list(etree.find("related-objects")):
-        related_object_name = related_object.find("name").text + ".Id"
+        related_object_name = related_object.find("name").text
+
+        if related_object_name in UNSUPPORTED_RELATED_OBJECTS:
+            LOGGER.info(f"{related_object_name} cannot be queried with {stream_name}")
+            continue
+
+        related_object_name = related_object_name + ".Id"
+
         field_dict[related_object_name] = {
             "type": "string",
             "required": False,

--- a/tests/base.py
+++ b/tests/base.py
@@ -53,6 +53,13 @@ class ZuoraBaseTest(unittest.TestCase):
         "JournalEntryDetailInvoiceItemAdjustment",
     }
 
+    #BUG: https://jira.talendforge.org/browse/TDL-21812
+    streams_not_under_test = {
+        "JournalEntryDetailRealizedFxGainLoss",
+        "JournalEntryDetailUnrealizedFxGainLoss",
+        "SubscriptionStatusHistory",
+    }
+
     def name(self):
         return "tap_tester_zuora"
 

--- a/tests/test_zuora_discovery.py
+++ b/tests/test_zuora_discovery.py
@@ -44,7 +44,7 @@ class DiscoveryTest(ZuoraBaseTest):
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         # verify the tap only discovers the expected streams
-        found_catalog_names = {catalog["tap_stream_id"] for catalog in found_catalogs}
+        found_catalog_names = {catalog["tap_stream_id"] for catalog in found_catalogs} - self.streams_not_under_test
         self.assertSetEqual(streams_to_test, found_catalog_names)
         LOGGER.info("discovered schemas are OK")
 


### PR DESCRIPTION
# Description of change
Related Object identifiers are not necessarily queryable with a given object. If a field is known to cause issues when included as a related object, do not add that field to a stream's field_dict.

# Manual QA steps
 - Tested with cloned connection

# Risks
 - Low; these fields cannot be queried on related objects currently.

# Rollback steps
 - revert this branch
