### PR TITLE
Add Central Sandbox URLs for NA and EU

### DIFF
--- a/tap_zuora/client.py
+++ b/tap_zuora/client.py
@@ -25,9 +25,13 @@ URLS = {
     (IS_SAND, NOT_EURO): [
         "https://rest.sandbox.na.zuora.com/",
         "https://rest.apisandbox.zuora.com/",
+        "https://rest.test.zuora.com"
     ],
     (IS_PROD, IS_EURO): ["https://rest.eu.zuora.com/"],
-    (IS_SAND, IS_EURO): ["https://rest.sandbox.eu.zuora.com/"],
+    (IS_SAND, IS_EURO): [
+        "https://rest.sandbox.eu.zuora.com/",
+        "https://rest.test.eu.zuora.com"
+    ],
 }
 
 LATEST_WSDL_VERSION = "91.0"


### PR DESCRIPTION
# Description of change
The current Zuora integration supports API sandboxes but not the Central Sandboxes. This change updates the set of possible URLs to include all URLs from [this documentation](https://developer.zuora.com/v1-api-reference/introduction/).

# Manual QA steps
 - Verify integrating with a central sandbox works as well

# Risks
 - No obvious risks here as all Zuora environments use the same API scheme and the code is designed to handle failures of the URLs gracefull

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
