### PR TITLE
TDL-27477: Update Unsupported Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.1
+  * Remove unsupported fields `IncludeOrderLineItems` and `IncludeSubscriptions` from `BillingRun` stream [#81](https://github.com/singer-io/tap-zuora/pull/81)
+
 ## 1.5.0
   * Add oauth option for authorization [#79](https://github.com/singer-io/tap-zuora/pull/79)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-zuora",
-    version="1.5.0",
+    version="1.5.1",
     description="Singer.io tap for extracting data from the Zuora API",
     author="Stitch",
     url="https://singer.io",

--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -39,7 +39,7 @@ UNSUPPORTED_FIELDS_FOR_REST = {
         "RemovedRatePlanId",
         "SubType",
     ],
-    "BillingRun": ["BillingRunType", "NumberOfCreditMemos", "PostedDate", "Name"],
+    "BillingRun": ["BillingRunType", "NumberOfCreditMemos", "PostedDate", "Name", "IncludeOrderLineItems"],
     "Contact": ["AsBillTo", "AsShipTo", "AsSoldTo"],
     "Export": ["Encoding", "SnowflakeWarehouse", "SourceData", "WarehouseSize"],
     "Invoice": ["PaymentTerm",

--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -39,7 +39,7 @@ UNSUPPORTED_FIELDS_FOR_REST = {
         "RemovedRatePlanId",
         "SubType",
     ],
-    "BillingRun": ["BillingRunType", "NumberOfCreditMemos", "PostedDate", "Name", "IncludeOrderLineItems"],
+    "BillingRun": ["BillingRunType", "NumberOfCreditMemos", "PostedDate", "Name", "IncludeOrderLineItems", "IncludeSubscriptions"],
     "Contact": ["AsBillTo", "AsShipTo", "AsSoldTo"],
     "Export": ["Encoding", "SnowflakeWarehouse", "SourceData", "WarehouseSize"],
     "Invoice": ["PaymentTerm",

--- a/tests/base.py
+++ b/tests/base.py
@@ -564,15 +564,16 @@ class ZuoraBaseTest(unittest.TestCase):
             interrupted_stream_bookmark = bookmark_state.get(interrupt_stream, {})
             interrupted_stream_bookmark.pop("offset", None)
             interrupted_stream_rec = []
-            for record in sync_records.get(interrupt_stream).get("messages"):
+            for record in sync_records.get(interrupt_stream, {}).get("messages", []):
                 if record.get("action") == "upsert":
                     rec = record.get("data")
                     interrupted_stream_rec.append(rec)
 
             # Set a deferred bookmark value for both the bookmarks of chat stream
-            rec_index = len(interrupted_stream_rec) // 2 if len(interrupted_stream_rec) > 1 else 0
-            interrupted_stream_bookmark[replication_key] = interrupted_stream_rec[rec_index][replication_key]
+            if len(interrupted_stream_rec) > 0:
+                rec_index = len(interrupted_stream_rec) // 2
+                interrupted_stream_bookmark[replication_key] = interrupted_stream_rec[rec_index][replication_key]
 
-            bookmark_state[interrupt_stream] = interrupted_stream_bookmark
-            interrupted_sync_states["bookmarks"] = bookmark_state
+                bookmark_state[interrupt_stream] = interrupted_stream_bookmark
+                interrupted_sync_states["bookmarks"] = bookmark_state
         return interrupted_sync_states

--- a/tests/test_zuora_interrupted_sync.py
+++ b/tests/test_zuora_interrupted_sync.py
@@ -43,7 +43,7 @@ class ZuoraInterruptedSyncTest(ZuoraBaseTest):
         """
         self.zuora_api_type = api_type
         self.start_date = dt.strftime(utils.now() - timedelta(days=10), "%Y-%m-%dT00:00:00Z")
-        expected_streams = {"PaymentMethodTransactionLog", "OrderAction", "RatePlan"}
+        expected_streams = {"PaymentMethodTransactionLog"}
 
         conn_id = connections.ensure_connection(self, original_properties=False)
 


### PR DESCRIPTION
# Description of change
- Adds `IncludeOrderLineItems` and `IncludeSubscriptions` to the list of unsupported fields for the stream `BillingRun`
- Updates tests to skip empty streams

# Manual QA steps
 -

# Risks
 -

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
