### PR TITLE
SAC-29405 - Add ClearingExistingCommunicationProfile to UNSUPPORTED_FIELDS_FOR_REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## 1.6.0
-  * Update libraries [#87] (https://github.com/singer-io/tap-zuora/pull/87)
+  * Add `CommunicationProfileId` and `OrderId` in unsupported discovery fields [#88](https://github.com/singer-io/tap-zuora/pull/88)
+  * Update libraries [#87](https://github.com/singer-io/tap-zuora/pull/87)
   * Code Refactoring [#86](https://github.com/singer-io/tap-zuora/pull/86)
-   - Add `CommunicationProfileId` to the `UNSUPPORTED_FIELDS_FOR_REST` for multiple streams
-   - Included `NotificationHistoryEmailEvent` in the expected streams for both REST and BULK (AQUA) APIs to ensure catalog discovery
+    - Add `NotificationHistoryEmailEvent` to the expected streams for both REST and BULK (AQUA) APIs to ensure correct catalog discovery
 
 ## 1.5.2
   * Bump dependency versions for twistlock compliance [#82](https://github.com/singer-io/tap-zuora/pull/82)

--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -133,6 +133,7 @@ UNSUPPORTED_FIELDS_FOR_REST = {
         "RolloverPeriodLength",
         "RolloverPeriods",
         "SpecificListPriceBase",
+        "UpsellOriginChargeNumber",
     ],
     "RevenueRecognitionEventsTransaction": ["UsageChargeName", "UsageChargeNumber"],
     "Subscription": ["IsLatestVersion",

--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -145,7 +145,8 @@ UNSUPPORTED_FIELDS_FOR_REST = {
                      "InvoiceTemplateId",
                      "SequenceSetId",
                      "CommunicationProfileId",
-    ],
+                     "OrderId"
+                     ],
     "TaxationItem": ["Balance", "CreditAmount", "PaymentAmount"],
     "Usage": ["ImportId"],
 }

--- a/tap_zuora/discover.py
+++ b/tap_zuora/discover.py
@@ -68,7 +68,10 @@ UNSUPPORTED_FIELDS_FOR_REST = {
                     "SubscriptionNumber",
     ],
     "InvoiceItemAdjustment": ["ExcludeItemBillingFromRevenueAccounting"],
-    "OrderAction": ["ClearingExistingShipToContact", "CommunicationProfileId"],
+    "OrderAction": ["ClearingExistingShipToContact",
+                    "CommunicationProfileId",
+                    "ClearingExistingCommunicationProfile"
+    ],
     "OrderLineItem": ["ShipTo", "CommunicationProfileId"],
     "PaymentMethod": ["StoredCredentialProfileId", "PaymentMethodTokenId"],
     "Product": ["ProductNumber"],


### PR DESCRIPTION
# Description of change
Added `ClearingExistingCommunicationProfile` as unsupported for Zuora REST API by including it in the `UNSUPPORTED_FIELDS_FOR_REST` for OrderAction stream. This prevents unsupported field errors during sync and discovery when using REST API.


Ticket: [SAC-29405](https://qlik-dev.atlassian.net/browse/SAC-29405)

### Changes

| File | Description |
| ---- | ----------- |
| tap_zuora/discover.py | Added `ClearingExistingCommunicationProfile` to UNSUPPORTED_FIELDS_FOR_REST for OrderAction stream |



---

# Manual QA steps
 Run discovery and sync for REST and AQUA APIs to verify that no unsupported field errors occur for `ClearingExistingCommunicationProfile`.

# Risks
 -

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
